### PR TITLE
Introduce cargo mutants cron job

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,9 @@
+additional_cargo_args = ["--all-features"]
+examine_globs = ["payjoin/src/**/*.rs", "payjoin-cli/src/**/*.rs"]
+exclude_globs = []
+exclude_re = [
+	"impl Debug",
+	"impl Display",
+	"deserialize",
+	"Iterator"
+]

--- a/.github/workflows/cron-weekly-mutants.yml
+++ b/.github/workflows/cron-weekly-mutants.yml
@@ -1,0 +1,39 @@
+name: Weekly cargo-mutants
+on: 
+  schedule: 
+    - cron: "0 0 * * 0" # runs weekly on Sunday at 00:00
+  workflow_dispatch: # allows manual triggering
+jobs:
+  cargo-mutants:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-mutants
+      - run: cargo mutants --in-place --no-shuffle
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: mutants.out
+          path: mutants.out
+      - name: Check for new mutants
+        if: always()
+        run: |
+          if [ -s mutants.out/missed.txt ]; then
+            echo "New missed mutants found"
+            gh issue create \
+            --title "New Mutants Found" \
+            --body "$(cat <<EOF
+          Displaying up to the first 15 missed mutants:
+          $(head -n 15 mutants.out/missed.txt)
+          For the complete list, please check the [mutants.out artifact](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+          EOF
+          )"
+            echo "create_issue=true" >> $GITHUB_ENV
+          else
+            echo "No new mutants found"
+            echo "create_issue=false" >> $GITHUB_ENV
+          fi
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 *payjoin.sled
 Cargo.lock
 .vscode
+mutants.out


### PR DESCRIPTION
At the moment all cargo mutant exploration I have been doing locally but with over 250 missed mutants remaining and possibly growing as new code is introduced I think it is time to implement a weekly cron job to track these mutants.

This heavily copies the rust-bitcoin implementation of their mutants workflow with tweaks for our codebase and mutants coverage progress.