### PR TITLE
Remove macos workflow redis dependency

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -90,23 +90,6 @@ jobs:
       - name: Setup Docker on macOS
         uses: douglascamata/setup-docker-macos-action@v1.0.0
 
-      - name: "Install Redis"
-        run: |
-          brew update
-          brew install redis
-
-      - name: "Start Redis"
-        run: |
-          redis-server --daemonize yes
-          for i in {1..10}; do
-            if redis-cli ping | grep -q PONG; then
-              echo "Redis is ready"
-              break
-            fi
-            echo "Waiting for Redis..."
-            sleep 1
-          done
-
       - name: "Use cache"
         uses: Swatinem/rust-cache@v2
 

--- a/payjoin-ffi/README.md
+++ b/payjoin-ffi/README.md
@@ -53,3 +53,5 @@ cargo test  --package payjoin_ffi --test bdk_integration_test v2_to_v2_full_cycl
 
 This project is in active development and currently in its Alpha stage. **Please proceed with caution**, particularly when using real funds.
 We encourage thorough review, testing, and contributions to help improve its stability and security before considering production use.
+
+force build


### PR DESCRIPTION
We should use the redis within the payjoin-test-utils and not install redis seperately.