### PR TITLE
Create nightly ci to prevent nightly CI failures in contrib PRs

### DIFF
--- a/.github/workflows/cron-weekly-update-nightly.yml
+++ b/.github/workflows/cron-weekly-update-nightly.yml
@@ -1,0 +1,43 @@
+name: Update Nightly rustc
+on:
+  push:
+  schedule:
+    - cron: "5 0 * * 6" # Saturday at 00:05
+  workflow_dispatch: # allows manual triggering
+jobs:
+  format:
+    name: Update nightly rustc
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Update rust.yml to use latest nightly
+        run: |
+          set -x
+          # Not every night has a nightly, so extract the date from whatever
+          # version of the compiler dtolnay/rust-toolchain gives us.
+          NIGHTLY_DATE=$(rustc +nightly --verbose --version | sed -ne 's/^commit-date: //p')
+          # Update the nightly version in the reference file.
+          echo -e "[toolchain]\nchannel = \"nightly-${NIGHTLY_DATE}\"\ncomponents = [\"rust-analyzer\", \"rust-src\", \"rustfmt\", \"clippy\"]" > rust-toolchain.toml
+          echo "nightly_date=${NIGHTLY_DATE}" >> $GITHUB_ENV
+          # Some days there is no new nightly. In this case don't make an empty PR.
+          if ! git diff --exit-code > /dev/null; then
+              echo "Updated nightly. Opening PR."
+              echo "changes_made=true" >> $GITHUB_ENV
+          else
+              echo "Attempted to update nightly but the latest-nightly date did not change. Not opening any PR."
+              echo "changes_made=false" >> $GITHUB_ENV
+          fi
+      - name: Create Pull Request
+        if: env.changes_made == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.BENALLENG_CREATE_PR_TOKEN }}
+          author: Update Nightly Rustc Bot <bot@example.com>
+          committer: Update Nightly Rustc Bot <bot@example.com>
+          title: Automated daily update to rustc (to nightly-${{ env.nightly_date }})
+          body: |
+           Automated update to Github CI workflow `rust.yml` by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
+          commit-message: Automated update to Github CI to rustc nightly-${{ env.nightly_date }}
+          branch: create-pull-request/weekly-nightly-ci-check
+          delete-branch: true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly"
-components = ["rust-analyzer", "rust-src"]
+channel = "nightly-2025-10-09"
+components = ["rust-analyzer", "rust-src", "rustfmt", "clippy"]


### PR DESCRIPTION
<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [ ] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [ ] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
