### PR TITLE
Add async weekly standup automation

### DIFF
--- a/.github/scripts/compile_standup.py
+++ b/.github/scripts/compile_standup.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Compile standup responses into a GitHub Discussion and close the issue."""
+
+import os
+from datetime import datetime, timezone, timedelta
+
+import requests
+
+REPO = os.environ["GITHUB_REPOSITORY"]
+TOKEN = os.environ["STANDUP_TOKEN"]
+CATEGORY_NODE_ID = os.environ["DISCUSSION_CATEGORY_NODE_ID"]
+API = "https://api.github.com"
+GRAPHQL = "https://api.github.com/graphql"
+HEADERS = {
+    "Authorization": f"token {TOKEN}",
+    "Accept": "application/vnd.github+json",
+}
+
+
+def find_standup_issue():
+    """Find the most recent open standup-input issue from the last 7 days."""
+    since = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat()
+    resp = requests.get(
+        f"{API}/repos/{REPO}/issues",
+        headers=HEADERS,
+        params={
+            "labels": "standup-input",
+            "state": "open",
+            "since": since,
+            "sort": "created",
+            "direction": "desc",
+            "per_page": 1,
+        },
+    )
+    resp.raise_for_status()
+    issues = resp.json()
+    if not issues:
+        print("No standup-input issue found in the last 7 days.")
+        return None
+    return issues[0]
+
+
+def fetch_comments(issue_number):
+    """Fetch all comments on an issue."""
+    comments = []
+    page = 1
+    while True:
+        resp = requests.get(
+            f"{API}/repos/{REPO}/issues/{issue_number}/comments",
+            headers=HEADERS,
+            params={"per_page": 100, "page": page},
+        )
+        resp.raise_for_status()
+        batch = resp.json()
+        if not batch:
+            break
+        comments.extend(batch)
+        page += 1
+    return comments
+
+
+def get_repo_node_id():
+    """Get the repository node ID for the GraphQL mutation."""
+    resp = requests.get(f"{API}/repos/{REPO}", headers=HEADERS)
+    resp.raise_for_status()
+    return resp.json()["node_id"]
+
+
+def create_discussion(title, body, repo_node_id):
+    """Create a GitHub Discussion via GraphQL."""
+    mutation = """
+    mutation($repoId: ID!, $categoryId: ID!, $title: String!, $body: String!) {
+      createDiscussion(input: {
+        repositoryId: $repoId,
+        categoryId: $categoryId,
+        title: $title,
+        body: $body
+      }) {
+        discussion {
+          url
+        }
+      }
+    }
+    """
+    resp = requests.post(
+        GRAPHQL,
+        headers=HEADERS,
+        json={
+            "query": mutation,
+            "variables": {
+                "repoId": repo_node_id,
+                "categoryId": CATEGORY_NODE_ID,
+                "title": title,
+                "body": body,
+            },
+        },
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    if "errors" in data:
+        raise RuntimeError(f"GraphQL errors: {data['errors']}")
+    return data["data"]["createDiscussion"]["discussion"]["url"]
+
+
+def close_issue(issue_number, discussion_url):
+    """Close the standup issue with a link to the compiled discussion."""
+    requests.post(
+        f"{API}/repos/{REPO}/issues/{issue_number}/comments",
+        headers=HEADERS,
+        json={"body": f"Compiled into discussion: {discussion_url}"},
+    )
+    requests.patch(
+        f"{API}/repos/{REPO}/issues/{issue_number}",
+        headers=HEADERS,
+        json={"state": "closed"},
+    )
+
+
+def main():
+    issue = find_standup_issue()
+    if not issue:
+        return
+
+    issue_number = issue["number"]
+    # Extract the week label from the issue title
+    title_suffix = issue["title"].removeprefix("Standup Input: ")
+    week_label = title_suffix or datetime.now(timezone.utc).strftime("Week of %Y-%m-%d")
+
+    comments = fetch_comments(issue_number)
+
+    # Build sections per contributor
+    sections = []
+    for comment in comments:
+        user = comment["user"]["login"]
+        if comment["user"]["type"] == "Bot":
+            continue
+        body = comment["body"].strip()
+        sections.append(f"### @{user}\n{body}")
+
+    updates = "\n\n".join(sections) if sections else "_No responses._"
+
+    discussion_title = f"Weekly Check-in: {week_label}"
+    discussion_body = updates
+
+    repo_node_id = get_repo_node_id()
+    discussion_url = create_discussion(discussion_title, discussion_body, repo_node_id)
+    print(f"Created discussion: {discussion_url}")
+
+    close_issue(issue_number, discussion_url)
+    print(f"Closed issue #{issue_number}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/create_standup_issue.py
+++ b/.github/scripts/create_standup_issue.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Create a weekly standup input issue and ping contributors."""
+
+import os
+from datetime import datetime, timezone
+
+import requests
+
+REPO = os.environ["GITHUB_REPOSITORY"]
+TOKEN = os.environ["STANDUP_TOKEN"]
+API = "https://api.github.com"
+HEADERS = {
+    "Authorization": f"token {TOKEN}",
+    "Accept": "application/vnd.github+json",
+}
+
+CONTRIBUTORS = [
+    "DanGould",
+    "spacebear21",
+    "arminsabouri",
+    "benalleng",
+    "chavic",
+    "zealsham",
+    "Mshehu5",
+]
+
+
+def main():
+    today = datetime.now(timezone.utc)
+    week_label = today.strftime("%Y-%m-%d")
+    title = f"Standup Input: Week of {week_label}"
+
+    cc_line = " ".join(f"@{u}" for u in CONTRIBUTORS)
+    body = (
+        "Please reply by **Monday end-of-day** (your timezone).\n\n"
+        "Format:\n"
+        "- **Shipped**: What you landed last week (PR/issue links)\n"
+        "- **Focus**: What you're working on this week\n"
+        "- **Blockers**: Anything stopping you — name who can help\n\n"
+        f"cc {cc_line}"
+    )
+
+    # Ensure the label exists
+    label_url = f"{API}/repos/{REPO}/labels/standup-input"
+    resp = requests.get(label_url, headers=HEADERS)
+    if resp.status_code == 404:
+        requests.post(
+            f"{API}/repos/{REPO}/labels",
+            headers=HEADERS,
+            json={
+                "name": "standup-input",
+                "color": "0E8A16",
+                "description": "Weekly standup input issue",
+            },
+        )
+
+    # Create the issue
+    resp = requests.post(
+        f"{API}/repos/{REPO}/issues",
+        headers=HEADERS,
+        json={"title": title, "body": body, "labels": ["standup-input"]},
+    )
+    resp.raise_for_status()
+    issue = resp.json()
+    print(f"Created issue #{issue['number']}: {issue['html_url']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/standup-compile.yml
+++ b/.github/workflows/standup-compile.yml
@@ -1,0 +1,22 @@
+name: Standup Compile
+
+on:
+  schedule:
+    # Tuesday 06:00 UTC = Tuesday 14:00 Taipei
+    - cron: "0 6 * * 2"
+  workflow_dispatch:
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install requests
+      - run: python .github/scripts/compile_standup.py
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          STANDUP_TOKEN: ${{ secrets.STANDUP_TOKEN }}
+          DISCUSSION_CATEGORY_NODE_ID: ${{ secrets.DISCUSSION_CATEGORY_NODE_ID }}

--- a/.github/workflows/standup-prompt.yml
+++ b/.github/workflows/standup-prompt.yml
@@ -1,0 +1,21 @@
+name: Standup Prompt
+
+on:
+  schedule:
+    # Monday 00:00 UTC = Monday 08:00 Taipei
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+jobs:
+  create-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install requests
+      - run: python .github/scripts/create_standup_issue.py
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          STANDUP_TOKEN: ${{ secrets.STANDUP_TOKEN }}


### PR DESCRIPTION
Monday 00:00 UTC prompt creates an issue pinging all contributors.  Tuesday 06:00 UTC compile collects
responses into a GitHub Discussion and closes the issue.

Prompt is forward-looking (Shipped / Focus / Blockers) rather than purely retrospective so public commitments create natural accountability.

<details>
  <summary>Pull Request Checklist</summary>

Please confirm the following before requesting review:

- [ ] I have [disclosed my use of
      AI](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#ai-assistance-notice)
      in the body of this PR.
- [ ] I have read [CONTRIBUTING.md](https://github.com/payjoin/rust-payjoin/blob/master/.github/CONTRIBUTING.md#commits) and **rebased my branch to produce [hygienic commits](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md#committing-patches)**.
</details>
